### PR TITLE
Support RedHat by switching to GROG.package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - printf '[defaults]\nroles_path=../' >ansible.cfg
 
   # Install dependencies
-  - ansible-galaxy install SimpliField.packages SimpliField.path
+  - ansible-galaxy install GROG.package SimpliField.path
 
 script:
   # Basic role syntax check

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ ssl_dhparam_size: "2048"
 Dependencies
 ------------
 
-- [SimpliField.packages](https://galaxy.ansible.com/SimpliField/packages/)
+- [GROG.package](https://galaxy.ansible.com/GROG/package/)
 - [SimpliField.path](https://galaxy.ansible.com/SimpliField/path/)
 
 Example Playbook

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,14 +12,17 @@ galaxy_info:
     - vivid
     - wily
     - xenial
+  - name: EL
+    versions:
+    - 7
   galaxy_tags:
   - ssl
   - openssl
   - certificates
 dependencies:
-- role: SimpliField.packages
-  packages:
-  - openssl
+- role: GROG.package
+  package_list:
+  - name: openssl
 - role: SimpliField.path
   path: "/etc/ssl/{{ ssl_common_name }}"
   owner: "{{ ssl_path_owner }}"


### PR DESCRIPTION
Thanks for writing this great role! Fits perfectly into our NGINX deployment workflow

We'd like to be able to use this with both Debian and RedHat systems, and the only real dependency is package installation.

Your other role SimpliField.packages only supports Debian, but by switching to [GROG.package](https://galaxy.ansible.com/GROG/package/) this role can support RHEL and a bunch of other OS families!